### PR TITLE
#40224

### DIFF
--- a/src/Mammon/Mammon.csproj
+++ b/src/Mammon/Mammon.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="*" />
-    <PackageReference Include="Azure.Identity" Version="*" />
+    <PackageReference Include="Azure.Identity" Version="1.12.1" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="*" />
     <PackageReference Include="Azure.Monitor.Query" Version="*" />
     <PackageReference Include="Azure.ResourceManager.ApiManagement" Version="*" />


### PR DESCRIPTION
Specify Azure.Identity version as 1.12.1

Updated the Azure.Identity package version from a wildcard (*) to a specific version (1.12.1). This change ensures consistent dependency management and helps avoid potential issues with future versions.