### PR TITLE
feat: add revisionHistoryLimit: 2 to deployment

### DIFF
--- a/charts/Mammon/mammon/templates/deployment.yaml
+++ b/charts/Mammon/mammon/templates/deployment.yaml
@@ -7,6 +7,7 @@ metadata:
     service: mammon-service
 spec:
   replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
   selector:
     matchLabels:
       service: mammon-service

--- a/charts/Mammon/mammon/values.yaml
+++ b/charts/Mammon/mammon/values.yaml
@@ -1,4 +1,5 @@
 replicaCount: 1
+revisionHistoryLimit: 2
 
 service:
   type: ClusterIP


### PR DESCRIPTION
Adds revisionHistoryLimit: 2 to the mammon deployment spec.