### PR TITLE
fix: correct dangling secret store reference in kv-store component

### DIFF
--- a/devops/catalyst/mammon-kv-store.yaml
+++ b/devops/catalyst/mammon-kv-store.yaml
@@ -24,4 +24,4 @@ spec:
 scopes:
   - platform-mammon
 auth:
-  secretStore: mammon-azure-keyvault
+  secretStore: platform-mammon-azure-keyvault


### PR DESCRIPTION
The redis state store's auth.secretStore pointed at "mammon-azure-keyvault", but the deployed secret store component is named "platform-mammon-azure-keyvault". Dapr skips a component whose referenced secret store isn't loaded — no init, no error, no status — so the store never registered as the actor state store and every workflow call failed with "the state store is not configured to use the actor runtime", while the component sat in Pending.

Pointing auth.secretStore at the existing component lets the secretKeyRef metadata (REDIS--CONNECTIONSTRING, REDIS--KEY) resolve so the store can initialize and back the actor runtime.